### PR TITLE
update(config): configure the size plugin

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -43,3 +43,10 @@ config_updater:
 blunderbuss:
   request_count: 1
   use_status_availability: true
+
+size:
+  s: 10
+  m: 30
+  l: 90
+  xl: 270
+  xxl: 520


### PR DESCRIPTION
This PR configures the `size` Prow plugin.

I send it to double-check the `config-update` plugin is working as intended (we'd need to merge this PR to test it).