### PR TITLE
update(config): instruct roboquat to make /lgtm acts as /approve

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -4,6 +4,7 @@ approve:
       - gitpod-io/gitpod
       - gitpod-io/gitpod-test-repo
     require_self_approval: false
+    lgtm_acts_as_approve: true
     commandHelpLink: https://prow.gitpod-dev.com/command-help
   
 


### PR DESCRIPTION


As per https://github.com/kubernetes/test-infra/blob/e465d4fd9d61446fd3c7557d73c9f237b0ad1cf9/prow/plugins/approve/approve.go#L366