### PR TITLE
new(config): lgtm plugin config

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -6,7 +6,14 @@ approve:
     require_self_approval: false
     lgtm_acts_as_approve: true
     commandHelpLink: https://prow.gitpod-dev.com/command-help
-  
+
+lgtm:
+  - repos:
+      - gitpod-io/gitbot
+      - gitpod-io/gitpod
+      - gitpod-io/gitpod-test-repo
+    review_acts_as_lgtm: true
+    store_tree_hash: true
 
 plugins:
   gitpod-io/gitbot:


### PR DESCRIPTION
This PR configures the `lgtm` plugin so that:

- the GitHub review - ie. clicking all the 🟢 green buttons on the UI - acts as /lgtm
- it comments on the PR with the tree hash to detect squashed commits before removing lgtm labels