### PR TITLE
fix: disable self approval

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -1,12 +1,12 @@
 approve:
   - repos:
       - gitpod-io/gitbot
-    require_self_approval: false
+    require_self_approval: true
     lgtm_acts_as_approve: true
     commandHelpLink: https://prow.gitpod-dev.com/command-help
   - repos:
       - gitpod-io/gitpod
-    require_self_approval: false
+    require_self_approval: true
     lgtm_acts_as_approve: true
     issue_required: true
     commandHelpLink: https://prow.gitpod-dev.com/command-help


### PR DESCRIPTION
By looking at the [implementation code](https://github.com/kubernetes/test-infra/blob/9901b188a14600d62641c14c0d9003dae9fbdf9b/prow/plugins/config.go#L320) I noticed a negation.

Thus, since we do **not** want the authors to automatically self-approve their PRs (as per internal discussions), we need to revert those two values. Basically, specifying them as `false` is like not specifying them at all (ie., `nil`).