### PR TITLE
Presubmit that checks for good terraform code hygiene

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -123,3 +123,25 @@ size:
   l: 90
   xl: 270
   xxl: 520
+
+
+presubmits:
+  gitpod-com/gitpod:
+  - name: Terraform format checker
+    decorate: true
+    decoration_config:
+      ssh_key_secrets:
+      - roboquat-ssh-secret
+    always_run: false         
+    run_if_changed: "**.tf" 
+    skip_report: false
+    clone_uri: git@github.com:{{.Org}}/{{.Repo}}.git
+    skip_submodules: true
+    clone_depth: 0
+    spec:
+      containers:
+      - image: eu.gcr.io/gitpod-dev/gitpod-com/gitpod-ci:2
+        command:
+        - "make"
+        args:
+        - "terraform-lint"


### PR DESCRIPTION
I'm following [these docs](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#how-to-configure-new-jobs) to configure a presubmit job (One that runs on pull requests), to check for good terraform code hygiene in the gitpod-com repository.

This is meant to be just a Proof of Concept to enable prowjobs in our repos. If this job runs as we expect, then we can start creating more elaborated ones, such as integration tests for all PRs in gitpod-io/gitpod.


---
But to make this job run, I'll need some extra help 😬. 
* ProwJobs against private repositories require that we have a secret in our prow cluster with an ssh key of our beloved Roboquat. Where can I get access to the Roboquat account? If I can't, could someone create this secret for us? 


This PR depends on #22 to get merged first 🙂 