### PR TITLE
[config] don't require an issue on PRs

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -8,7 +8,6 @@ approve:
       - gitpod-io/gitpod
     require_self_approval: true
     lgtm_acts_as_approve: true
-    issue_required: true
     commandHelpLink: https://prow.gitpod-dev.com/command-help
 
 lgtm:


### PR DESCRIPTION
## Description
I find myself typing `/approve no-issue` multiple times a day. It doesn't seem to be a real prerequisite for out PRs, so I'd like to disable this check.

## Related Issue(s)
NONE 😄 

## Release Notes
```release-note
NONE
```

