### PR TITLE
[projectmanager] handle PRs the same as issues

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -88,6 +88,7 @@ external_plugins:
     endpoint: http://projectmanager.prow.svc.cluster.local:8787
     events:
     - issues
+    - pull_request
   - name: customlabels
     endpoint: http://customlabels.prow.svc.cluster.local:8787
     events:
@@ -105,6 +106,7 @@ external_plugins:
     endpoint: http://projectmanager.prow.svc.cluster.local:8787
     events:
     - issues
+    - pull_request
   - name: customlabels
     endpoint: http://customlabels.prow.svc.cluster.local:8787
     events:


### PR DESCRIPTION
This allows us to also handle PRs to the groundwork projects if we manually add them. This allows us to track work on reviewing PRs that don't have a linked issue.

Note: This is already deployed.