### PR TITLE
[config] Disable blunderbuss

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -43,7 +43,7 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
+    # - blunderbuss   ## https://gitpod.slack.com/archives/C01KGM9AW4W/p1635429357055900
     - cat
     - dog
     - help
@@ -61,7 +61,7 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
+    # - blunderbuss   ## https://gitpod.slack.com/archives/C01KGM9AW4W/p1635429357055900
     - cat
     - dog
     - goose


### PR DESCRIPTION
Disables auto-assigment of reviewers as per https://gitpod.slack.com/archives/C01KGM9AW4W/p1635429357055900

```release-notes
Disable automatic assignment of reviewers
```