### PR TITLE
[deploy-labeler] Add deployed label immediately

### DIFF
--- a/plugins/deployed-labeler/main.go
+++ b/plugins/deployed-labeler/main.go
@@ -160,6 +160,8 @@ func (s *server) updatePullRequests(prs []pullRequest, team string) (teamDeploye
 			err := s.gh.AddLabel(org, repo, pr.Number, teamDeployedLabel)
 			if err != nil {
 				errs = append(errs, err)
+			} else {
+				pr.Labels[teamDeployedLabel] = struct{}{}
 			}
 		}
 


### PR DESCRIPTION
## Description
Adds the `deployed` label immediately after the `deployed: team` label was added

```release-notes
None
```