### PR TITLE
Use GH review status instead of labels for tide query

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,9 +63,7 @@ tide:
     - do-not-merge/release-note-label-needed
   - repos:
     - gitpod-io/gitpod-test-repo
-    labels:
-    - lgtm
-    - approved
+    reviewApprovedRequired: true
     missingLabels:
     # no one's setting this label yet because we don't have the external needs-rebase plugin set up yet
     - needs-rebase


### PR DESCRIPTION
## Description

We want to use the Github review status rather than the `/lgtm` and `/approve` Prow commands for approving PRs. Before we can remove those commands we need to make sure that Tide (the component responsible for merging PRs) can be configured to merge PRs based on the GIthub review status rather than labels.

Based on my interpretation of the [docs here](https://github.com/kubernetes/test-infra/blob/f7e21a3c18f4f4bbc7ee170675ed53e4544a0632/prow/cmd/tide/config.md#queries) setting `reviewApprovedRequired` to true and removing the `labels` key should do just that.

This PR is just for the gitpod-io/gitpod-test-repo repository. If it works I will follow up with a PR for the other repository and also disable the `lgtm` and `approve` commands (by removing them from `config/plugins.yaml`)

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/6623

## How to test

I will open a PR in gitpod-io/gitpod-test-repo and approve it. I would expect prow to then merge it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

N/A
