### PR TITLE
Update OWNERS to contain Platform team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
-- leodido
-- csweichel
 - ArthurSens
+- meysholdt
+- mads-hartmann
+- wulfthimm


### PR DESCRIPTION
The Platform team owns Prow (gitbot). The OWNERS file should reflect that so we can merge our own PRs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```