### PR TITLE
Use GitHub reviews for all prow-managed repositories 

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,9 +51,7 @@ tide:
   queries:
   - repos:
     - gitpod-io/gitpod
-    labels:
-    - lgtm
-    - approved
+    reviewApprovedRequired: true
     missingLabels:
     # no one's setting this label yet because we don't have the external needs-rebase plugin set up yet
     - needs-rebase
@@ -73,9 +71,7 @@ tide:
     - do-not-merge/release-note-label-needed
   - repos:
     - gitpod-io/gitbot
-    labels:
-    - lgtm
-    - approved
+    reviewApprovedRequired: true
     missingLabels:
     # no one's setting this label yet because we don't have the external needs-rebase plugin set up yet
     - needs-rebase

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -1,29 +1,7 @@
-approve:
-  - repos:
-      - gitpod-io/gitbot
-    require_self_approval: true
-    lgtm_acts_as_approve: true
-    commandHelpLink: https://prow.gitpod-dev.com/command-help
-  - repos:
-      - gitpod-io/gitpod
-    require_self_approval: true
-    lgtm_acts_as_approve: true
-    issue_required: true
-    commandHelpLink: https://prow.gitpod-dev.com/command-help
-
-lgtm:
-  - repos:
-      - gitpod-io/gitbot
-      - gitpod-io/gitpod
-      - gitpod-io/gitpod-test-repo
-    review_acts_as_lgtm: true
-    store_tree_hash: true
-
 plugins:
   gitpod-io/gitbot:
     plugins:
     - config-updater
-    - approve
     - assign
     - blunderbuss
     - cat
@@ -32,7 +10,6 @@ plugins:
     - heart
     - hold
     - label
-    - lgtm
     - release-note
     - size
     - verify-owners
@@ -41,7 +18,6 @@ plugins:
     - owners-label
   gitpod-io/gitpod:
     plugins:
-    - approve
     - assign
     # - blunderbuss   ## https://gitpod.slack.com/archives/C01KGM9AW4W/p1635429357055900
     - cat
@@ -50,7 +26,6 @@ plugins:
     - heart
     - hold
     - label
-    - lgtm
     - release-note
     - size
     - verify-owners
@@ -59,7 +34,6 @@ plugins:
     - owners-label
   gitpod-io/gitpod-test-repo:
     plugins:
-    - approve
     - assign
     # - blunderbuss   ## https://gitpod.slack.com/archives/C01KGM9AW4W/p1635429357055900
     - cat
@@ -68,7 +42,6 @@ plugins:
     - help
     - heart
     - hold
-    - lgtm
     - release-note
     - size
     - verify-owners


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We want to use the Github review status rather than the `/lgtm` and `/approve` Prow commands for approving PRs. To achieve this there are two things we need to do.

- Make sure Tide merges PRs when they have been approved in GitHub. Previously it would look for the `lgtm` `approve` labels, now I should look for the GitHub review status. This is achieved by using `reviewApprovedRequired: true` and removing the `labels`. This was implemented for gitpot-io/gitpot-test-repo in https://github.com/gitpod-io/gitbot/pull/55 and tested in https://github.com/gitpod-io/gitpod-test-repo/pull/204
- Remove the `lgtm` and `approve` commands so that there is only one workflow for approving PRs. This has been achieved by removing the plugins.

Merging this PR has the **following consequences**

1. Anyone can approve a PR and tide will merge it. See example [here](https://github.com/gitpod-io/gitpod-test-repo/pull/204) - Prow wanted roboquat to be assigned. Mo reviewed in GH. Tide merged. The OWNERS file is now only used by the `assign` plugin to suggest who to assign a PR to - if it even is - it might not be used at all. Only the approve plugin mentions it https://prow.k8s.io/plugins

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6623

## How to test
<!-- Provide steps to test this PR -->

- Once this is merged the `lgtm` and `approve` commands should be gone from https://prow.gitpod-dev.com/command-help
- The Tide config in https://prow.gitpod-dev.com/tide should now have `and must be approved by GitHub review` in the merge requirements sections and not mention the `lgtm` and `approve` labels.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A