### PR TITLE
Use Tide to merge PRs in gitpod-io/ops

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -62,6 +62,11 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/release-note-label-needed
   - repos:
+    - gitpod-io/ops
+    reviewApprovedRequired: true
+    missingLabels:
+    - do-not-merge/hold
+  - repos:
     - gitpod-io/gitpod-test-repo
     reviewApprovedRequired: true
     missingLabels:


### PR DESCRIPTION
## Description
This enables Tide for merging PRs in gitpod-io/ops once they have been reviewed. This is the first step towards gitpod-io/ops/issues/116. The overall aproach will be

1. Have prow merge PRs once they're reviewed (This is this PR)
2. Switch to PR based workflow for commits (https://github.com/gitpod-io/ops/pull/423)
3. Enable CODEOWNERS (upcoming PR in gitpod-io/ops)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of gitpod-io/ops/issues/116

## How to test

Tide should start merging PRs in gitpod-io/ops once they're approved.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
N/A