### PR TITLE
Disable blunderbuss in gitops like all other repos

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -25,7 +25,7 @@ plugins:
     - config-updater
     - approve
     - assign
-    - blunderbuss
+    # - blunderbuss   ## https://gitpod.slack.com/archives/C01KGM9AW4W/p1635429357055900
     - cat
     - dog
     - help


### PR DESCRIPTION
## Description
Blunderbuss doesn't work as expected and we have disabled it in all other repos. This also disabled it for this repo.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, ad-hoc fix.

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A