### PR TITLE
Use rebase for ops repository

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,6 +48,7 @@ tide:
     gitpod-io/gitpod: rebase
     gitpod-io/gitpod-test-repo: rebase
     gitpod-io/gitbot: rebase
+    gitpod-io/ops: rebase
   queries:
   - repos:
     - gitpod-io/gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We want to use rebase as the merge method like the other repository.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of gitpod-io/ops/issues/116

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A