### PR TITLE
Add WIP plugin to the ops repository and add hold label

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,6 +67,7 @@ tide:
     reviewApprovedRequired: true
     missingLabels:
     - do-not-merge/hold
+    - do-not-merge/work-in-progress
   - repos:
     - gitpod-io/gitpod-test-repo
     reviewApprovedRequired: true

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -75,6 +75,9 @@ plugins:
     - wip
     - yuks
     - owners-label
+  gitpod-io/ops:
+    plugins:
+    - wip
 
 external_plugins:
   "gitpod-io/gitpod":


### PR DESCRIPTION
## Description

As part of https://github.com/gitpod-io/ops/issues/676 we discovered that Tide tried to merge draft PRs in the ops repository.

By adding the WIP plugin the do-not-merge/work-in-progress label is applied to DRAFT PRs. The Tide config for ops has been updated to exclude PRs with that label.

This follows the setup for the other repositories.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
The issue was found as part of https://github.com/gitpod-io/ops/issues/676

## How to test
<!-- Provide steps to test this PR -->

Once merged I will try to open a draft PR in the ops repo. Have someone approve it, and we should see that it no longer shows up in the Tide query [here](https://prow.gitpod-dev.com/tide).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
NONE