### PR TITLE
Rename WebApp team label

### DIFF
--- a/config/customlabels.yaml
+++ b/config/customlabels.yaml
@@ -2,14 +2,14 @@ orgsRepos:
   "gitpod-io/gitpod":
     - key: "team"
       values: 
-        - "meta"
+        - "webapp"
         - "workspace"
         - "IDE"
         - "self-hosted"
   "gitpod-io/gitpod-test-repo":
     - key: "team"
       values: 
-        - "meta"
+        - "webapp"
         - "workspace"
         - "IDE"
         - "self-hosted"


### PR DESCRIPTION
## Description

Now that we renamed the _Meta_ team to _WebApp_ team and also renamed the **team: meta** label to **team: webapp** label, we also need to update this triage automation so that pull requests that change team-specific components get associated with the new **team: webapp** label.

Cc @gitpod-io/engineering-webapp 

## Release Notes
```release-note
NONE
```