### PR TITLE
Switch to using GH reviews instead of approve labels

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -52,9 +52,7 @@ tide:
   queries:
   - repos:
     - gitpod-io/gitpod
-    labels:
-    - lgtm
-    - approved
+    reviewApprovedRequired: true
     missingLabels:
     # no one's setting this label yet because we don't have the external needs-rebase plugin set up yet
     - needs-rebase
@@ -80,9 +78,7 @@ tide:
     - do-not-merge/release-note-label-needed
   - repos:
     - gitpod-io/gitbot
-    labels:
-    - lgtm
-    - approved
+    reviewApprovedRequired: true
     missingLabels:
     # no one's setting this label yet because we don't have the external needs-rebase plugin set up yet
     - needs-rebase


### PR DESCRIPTION
Leaving 

## Description
<!-- Describe your changes in detail -->
Switch Tide to use GitHub Reviews instead of lgtm and approve labels for finding PRs that it should merge. This is part of the work require to switch fully over to GitHub Reviews ([epic](https://github.com/gitpod-io/ops/issues/838)).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/842

## How to test
<!-- Provide steps to test this PR -->

Once merged we can check the Tide query to verify it finds the correct PRs (this is the config already used in ops, so I'm pretty confident it works)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A