### PR TITLE
Use workspace full and copy things from ops

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,13 +1,9 @@
-FROM ubuntu:focal
+FROM gitpod/workspace-full:commit-f2d623ca9d270c2ce8560d2ca0f9ce71b105aff2
 
 USER root
 
 RUN apt-get update && \
     apt-get install -y curl gnupg2 software-properties-common unzip zip sudo make jq
-
-RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
-    # passwordless sudo for users in the 'sudo' group
-    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
 
 ### Docker client ###
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
@@ -53,12 +49,18 @@ RUN apt-get install -y apt-transport-https curl gnupg && \
 RUN curl -L https://golang.org/dl/go1.17.2.linux-amd64.tar.gz | tar -C /usr/local -xzv
 ENV PATH=$PATH:/usr/local/go/bin
 
+USER gitpod
+
+# Go
+ENV GOFLAGS="-mod=readonly"
+
 ### Google Cloud ###
 # https://cloud.google.com/sdk/docs/downloads-versioned-archives
 ARG GCS_DIR=/opt/google-cloud-sdk
 ENV PATH=$GCS_DIR/bin:$PATH
-RUN mkdir $GCS_DIR \
-    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-365.0.0-linux-x86_64.tar.gz \
+RUN sudo chown gitpod: /opt \
+    && mkdir $GCS_DIR \
+    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-354.0.0-linux-x86_64.tar.gz \
     | tar -xzvC /opt \
     && /opt/google-cloud-sdk/install.sh --quiet --usage-reporting=false --bash-completion=true \
     --additional-components docker-credential-gcr alpha beta \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The current workspace image didn't have Git which made it really tedious to make changes in Gitpod (you'd have to install git and copy over your config from another working workspace)

This uses workspace full and copies over things from ops based on a bit of trail an error.

I'm really hoping we can archive this repo entirely soon and move the everything to the ops repo so I consider this temporary.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

Open a workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A
