### PR TITLE
Update default merge_method to "squash" for gitpod-io/gitpod

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,7 +45,7 @@ plank:
 tide:
   target_url: https://prow.gitpod-dev.com/tide
   merge_method:
-    gitpod-io/gitpod: rebase
+    gitpod-io/gitpod: squash
     gitpod-io/gitpod-test-repo: rebase
     gitpod-io/gitbot: rebase
     gitpod-io/ops: rebase


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update default merge_method to "squash" for https://github.com/gitpod-io/gitpod.

Context: [Slack proposal](https://gitpod.slack.com/archives/C01KGM9AW4W/p1649148422787969) (internal)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update default merge_method to "squash" for gitpod-io/gitpod
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
