### PR TITLE
Set timeout to 120 seconds instead of the default 30

### DIFF
--- a/config/prow/deployed-labeler.yaml
+++ b/config/prow/deployed-labeler.yaml
@@ -56,6 +56,7 @@ metadata:
   name: deployed-labeler
   namespace: prow
 spec:
+  timeoutSec: 120
   healthCheck:
     # This has to be set manually to ensure that the GCP ingress validates the right health-check endpoint
     # We sincerely do not know where the number 30299 comes from, but it is working with this config
@@ -88,7 +89,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: deployed-labeler
-          image: eu.gcr.io/gitpod-core-dev/prow/deployed-labeler:dev
+          image: eu.gcr.io/gitpod-core-dev/prow/deployed-labeler:2
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/plugins/deployed-labeler/README.md
+++ b/plugins/deployed-labeler/README.md
@@ -83,14 +83,4 @@ Now push the image
 TAG=1 ./dev/push-image.sh
 ```
 
-Connect to the prow cluster in gitpod-core-dev
-
-```sh
-gcloud container clusters get-credentials prow --zone europe-west1-b --project gitpod-core-dev
-```
-
-Finally edit the deployment to update the image
-
-```sh
-kubectl -n prow edit deployment deployed-labeler
-```
+Update the version for the deployed-labeler deployment in [config/prow/deployed-labeler.yaml](../../config/prow/deployed-labeler.yaml). The changes will be applied automatically when the PR is merged.


### PR DESCRIPTION
## Description

See [issue](https://github.com/gitpod-io/gitbot/issues/71) for context. This PR sets the timeout of the load balancer for the deployed labeler to 120s - the default is 30s. 

I also updated the README instructions on how to make changes to the k8s manifests for the deployed labeler.

I updated the deployment manifest so it doesn't revert the versions bumps we have been doing manually.

I have to verify it does apply the changes once the PR is merged though.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitbot/issues/71

## How to test
<!-- Provide steps to test this PR -->

I tried to manually edit the BackendConfig and verified that the load balancer updated it's config from 30s to 120s. I reverted the change again though as I want to verify that we do indeed automatically apply the manifests in this repo.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A