### PR TITLE
Update deploy instructions

### DIFF
--- a/config/prow/deployed-labeler.yaml
+++ b/config/prow/deployed-labeler.yaml
@@ -9,7 +9,7 @@ spec:
     - deployed-labeler.gitpod-dev.com
 ---
 kind: Ingress
-apiVersion: extensions/v1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: deployed-labeler
   namespace: prow

--- a/plugins/deployed-labeler/README.md
+++ b/plugins/deployed-labeler/README.md
@@ -83,4 +83,16 @@ Now push the image
 TAG=1 ./dev/push-image.sh
 ```
 
-Update the version for the deployed-labeler deployment in [config/prow/deployed-labeler.yaml](../../config/prow/deployed-labeler.yaml). The changes will be applied automatically when the PR is merged.
+Update the version for the deployed-labeler deployment in [config/prow/deployed-labeler.yaml](../../config/prow/deployed-labeler.yaml) and apply the changes manually:
+
+```sh
+# Login and connect to the cluster
+gcloud auth login
+gcloud container clusters get-credentials prow --zone europe-west1-b --project gitpod-core-dev
+
+# Verify the changes
+kubectl diff -f config/prow/deployed-labeler.yaml
+
+# Apply the changes
+kubectl apply -f config/prow/deployed-labeler.yaml
+```


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Turns out that only a few of the manifests are automatically applied. I updated the instructions and fixed the manifest for ingress.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitbot/issues/71, in https://github.com/gitpod-io/gitbot/pull/72 I had hoped the manifests would be applied automatically - they were not

## How to test
<!-- Provide steps to test this PR -->

I used the instructions to apply the manifests already.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A