### PR TITLE
Update deployed-labeler image

### DIFF
--- a/config/prow/deployed-labeler.yaml
+++ b/config/prow/deployed-labeler.yaml
@@ -89,7 +89,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: deployed-labeler
-          image: eu.gcr.io/gitpod-core-dev/prow/deployed-labeler:2
+          image: eu.gcr.io/gitpod-core-dev/prow/deployed-labeler:3
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
Just updates the image that contains the changes from https://github.com/gitpod-io/gitbot/pull/75

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
