### PR TITLE
Paginate retrieval of commit history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 secrets.yaml
+.idea


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds pagination so we can retrieve more than 100 records at a time, since GH GraphQL API has a hard limit on that: https://docs.github.com/en/graphql/overview/resource-limitations#node-limit


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```