### PR TITLE
Add hold plugin to ops to make UX consistent

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -20,6 +20,7 @@ plugins:
       - wip
   gitpod-io/ops:
     plugins:
+      - hold
       - wip
 
 config_updater:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds the hold plugin to the ops repository to make the UX consistent with what we have in gitpod.

While we'll want to remove Prow eventually, until then, it should work consistently between gitpod and ops.

Issue was raised [here](https://github.com/gitpod-io/ops/pull/2883#issuecomment-1163658580)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A