### PR TITLE
Enable `needs-rebase` plugin to `ops` repository

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,6 +63,7 @@ tide:
     - gitpod-io/ops
     reviewApprovedRequired: true
     missingLabels:
+    - needs-rebase
     - do-not-merge/hold
     - do-not-merge/work-in-progress
   - repos:

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -36,3 +36,9 @@ size:
   l: 90
   xl: 270
   xxl: 520
+
+external_plugins:
+  gitpod-io/ops:
+  - name: needs-rebase
+    events:
+    - pull_request


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Enables plugin that blocks the merging of PRs that needs to be rebased.

The situation we want to avoid is a timeline like this:
* PR 1 proposes changes to `main`, tests are green
* PR 2 proposes changes to `main`, tests are green
* PR 1 is merged, tests for `main` are green
* PR 2 is merged since the PR is green, but tests on `main` aren't green anymore because of conflicts between PR 1 and PR 2

The plugin was enabled following [this documentation](https://github.com/kubernetes/test-infra/blob/master/prow/plugins/README.md#external-plugins)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
