### PR TITLE
Rename blocker label following convention

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,7 +59,7 @@ tide:
     - do-not-merge/hold
     - do-not-merge/work-in-progress
     - do-not-merge/release-note-label-needed
-    - "cla: pending :hourglass_flowing_sand:"
+    - do-not-merge/cla-pending
   - repos:
     - gitpod-io/ops
     reviewApprovedRequired: true


### PR DESCRIPTION
## Description
This renames the CLA blocker to be similar as the other blockers, and signifies it clearer visually.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Community contributions cannot be merged without a signed CLA.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
