### PR TITLE
build: update workspace gcloud to 400.0.0

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -55,14 +55,16 @@ USER gitpod
 ENV GOFLAGS="-mod=readonly"
 
 ### Google Cloud ###
-# https://cloud.google.com/sdk/docs/downloads-versioned-archives
+# not installed via repository as then 'docker-credential-gcr' is not available
 ARG GCS_DIR=/opt/google-cloud-sdk
 ENV PATH=$GCS_DIR/bin:$PATH
 RUN sudo chown gitpod: /opt \
     && mkdir $GCS_DIR \
-    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-354.0.0-linux-x86_64.tar.gz \
+    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-400.0.0-linux-x86_64.tar.gz \
     | tar -xzvC /opt \
     && /opt/google-cloud-sdk/install.sh --quiet --usage-reporting=false --bash-completion=true \
-    --additional-components docker-credential-gcr alpha beta \
+    --additional-components gke-gcloud-auth-plugin docker-credential-gcr alpha beta \
     # needed for access to our private registries
     && docker-credential-gcr configure-docker
+
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True


### PR DESCRIPTION
## Description

gcloud 354.0.0 is old enough that `gcloud auth login` no longer works. This commit bumps the gcloud version to a more recent one (that we're using in gitpod-io/gitpod).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Confirm that the gcloud version is new enough to auth:

```bash
gcloud auth login
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
