### PR TITLE
deployed-labeler: improve error handling, add GET endpoint

### DIFF
--- a/plugins/deployed-labeler/README.md
+++ b/plugins/deployed-labeler/README.md
@@ -7,7 +7,7 @@ Accepts `POST` requests, while requiring to parameters:
 - `commit`: Commit that has just been deployed to production.
 - `team`: Which team just deployed to production.
 
-`deployed-labeler` will look for the last 100 commits of the repository's default branch, alongside their associated Pull Requests and labels.
+`deployed-labeler` will look for the last 500 commits of the repository's default branch, alongside their associated Pull Requests and labels.
 
 ![image](https://user-images.githubusercontent.com/24193764/139254510-9f8ed8e1-e9ac-4177-b447-49932b804edd.png)
 

--- a/plugins/deployed-labeler/README.md
+++ b/plugins/deployed-labeler/README.md
@@ -51,9 +51,15 @@ docker run \
 
 And `curl` the endpoint
 
-```sh
-curl -XPOST "http://localhost:8080/deployed?commit=01f4897c5323433e7831ca948f7d340c3c762885&team=webapp"
-```
+- Check for unlabeled pull requests:
+    ```sh
+    curl "http://localhost:8080/deployed?commit=01f4897c5323433e7831ca948f7d340c3c762885&team=webapp"
+    ```
+
+- Upload pull request labels:
+    ```sh
+    curl -XPOST "http://localhost:8080/deployed?commit=01f4897c5323433e7831ca948f7d340c3c762885&team=webapp"
+    ```
 
 ## Deploying
 

--- a/plugins/deployed-labeler/main.go
+++ b/plugins/deployed-labeler/main.go
@@ -212,8 +212,12 @@ func (s *server) getMergedPRs(ctx context.Context, commitSHA string) ([]pullRequ
 	var commits []commitNodes
 
 	// we get 100 commits per page
-	// 3x100 = 300 in total
-	for i := 0; i < 3; i++ {
+	// 5x100 = 500 in total
+	//
+	// Note that this value is sensitive to the commit rate of the given repo and the interval at which teams deploy;
+	// if more than 500 commits are merged within a week and a given team only deploys on a weekly basis then some commits
+	// might not be labeled.
+	for i := 0; i < 5; i++ {
 		err := s.gh.Query(ctx, &q, variables)
 		if err != nil {
 			s.log.WithError(err).Error("Error running query.")


### PR DESCRIPTION
## Description

deployed-labeler: bump commit limit to 5 pages, 100 results

- - -

deployed-labeler: emit error messages from /deployed endpoint
    
This commit generates user readable error messages when the /deployed endpoint is called without required parameters.

- - -

deployed-labeler: expose log level CLI option, adjust log levels

- - -

deployed-labeler: add GET handler for deployed to indicate label status

- - -

deployed-labeler: serialise errors as strings
    
per https://github.com/golang/go/issues/5161 serializing an `error` object to json emits an empty object; this caused deployed-labeler to emit an empty object when erroring. This commit converts all errors to strings before returning to the user to provide more context.

## Related Issue(s)

## How to test

Test error handling
1. Create a malformed GitHub key
2. Run `curl "http://localhost:8080/deployed?commit=470062367333b5d9992188dbc9ff89465c0ab1e3&team=workspace"`
3. verify that an error is emitted and returned to the user.

Test status endpoint
1. Remove the deployed labels from https://github.com/gitpod-io/gitpod/pull/14215
2. run `curl "http://localhost:8080/deployed?commit=470062367333b5d9992188dbc9ff89465c0ab1e3&team=workspace"`
3. confirm that the correct PR is listed as unlabeled

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
