### PR TITLE
[deployed-labeler] Bump image tag to `5`

### DIFF
--- a/config/prow/deployed-labeler.yaml
+++ b/config/prow/deployed-labeler.yaml
@@ -26,7 +26,7 @@ spec:
             backend:
               service:
                 name: deployed-labeler
-                port: 
+                port:
                   name: http
 ---
 apiVersion: v1
@@ -89,7 +89,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: deployed-labeler
-          image: eu.gcr.io/gitpod-core-dev/prow/deployed-labeler:4
+          image: eu.gcr.io/gitpod-core-dev/prow/deployed-labeler:5
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Image is built and pushed, and the deployment is updated. This PR updates the tag in the repo for consistency purposes.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[deployed-labeler] Bump image tag to `5`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
