### PR TITLE
Add hold and wip plugin to dedicated

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -12,6 +12,10 @@ plugins:
       - release-note
       - size
       - wip
+  gitpod-io/gitpod-dedicated:
+    plugins:
+      - hold
+      - wip
   gitpod-io/gitpod-test-repo:
     plugins:
       - hold


### PR DESCRIPTION
## Description

This adds the hold and wip plugins to gitpod-io/gitpod-dedicated. This adds the `do-not-merge/hold` label when you use the /hold command and ensure that `do-not-merge/work-in-progress` label is added for draft PRs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A