### PR TITLE
Remove release note plugin

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -60,7 +60,6 @@ tide:
     - needs-rebase
     - do-not-merge/hold
     - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
     - do-not-merge/cla-pending
   - repos:
     - gitpod-io/ops
@@ -77,7 +76,6 @@ tide:
     - needs-rebase
     - do-not-merge/hold
     - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
   - repos:
     - gitpod-io/gitbot
     reviewApprovedRequired: true
@@ -86,7 +84,6 @@ tide:
     - needs-rebase
     - do-not-merge/hold
     - do-not-merge/work-in-progress
-    - do-not-merge/release-note-label-needed
   context_options:
     # Use branch protection options to define required and optional contexts
     from-branch-protection: true

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -3,13 +3,11 @@ plugins:
     plugins:
       - config-updater
       - hold
-      - release-note
       - size
       - wip
   gitpod-io/gitpod:
     plugins:
       - hold
-      - release-note
       - size
       - wip
   gitpod-io/gitpod-dedicated:
@@ -19,7 +17,6 @@ plugins:
   gitpod-io/gitpod-test-repo:
     plugins:
       - hold
-      - release-note
       - size
       - wip
   gitpod-io/ops:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

https://gitpod.slack.com/archives/C01KGM9AW4W/p1681772025192589?thread_ts=1681210638.197189&cid=C01KGM9AW4W

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
