### PR TITLE
[deploy-labeler] get less commits per page

### DIFF
--- a/plugins/deployed-labeler/main.go
+++ b/plugins/deployed-labeler/main.go
@@ -284,16 +284,16 @@ func (s *server) getMergedPRs(ctx context.Context, commitSHA string) ([]pullRequ
 	var q query
 	var commits []commitNodes
 
-	// we get 100 commits per page
-	// 5x100 = 500 in total
+	// we get 10 commits per page
+	// 10x50 = 500 in total
 	//
 	// Note that this value is sensitive to the commit rate of the given repo and the interval at which teams deploy;
 	// if more than 500 commits are merged within a week and a given team only deploys on a weekly basis then some commits
 	// might not be labeled.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 50; i++ {
 		err := s.gh.Query(ctx, &q, variables)
 		if err != nil {
-			s.log.WithError(err).Error("Error running query.")
+			s.log.WithField("query", q).WithError(err).Error("Error running query.")
 			return nil, err
 		}
 
@@ -346,7 +346,7 @@ type query struct {
 							HasNextPage bool
 						}
 						Nodes []commitNodes
-					} `graphql:"history(first: 100, after: $cursor)"`
+					} `graphql:"history(first: 10, after: $cursor)"`
 				} `graphql:"... on Commit"`
 			} `graphql:"object(oid: $commit)"`
 		} `graphql:"repository(name: $repo)"`


### PR DESCRIPTION
Fixes PDEO-48

Prior to this change, we're getting 502 errors when doing workspace deploys (at the end, our werft job curl's the deploy-labeler).

I tested with [dry-run](https://github.com/gitpod-io/gitbot/tree/main/plugins/deployed-labeler#developing) like so, and the results look promising:

```bash
gitpod /workspace/gitbot/plugins/deployed-labeler (kylos101/less-per-page) $ time curl -XPOST "http://localhost:8080/deployed?commit=${COMMIT}&team=workspace"
{
  "deployedPRs": {
    "team": [
      "https://github.com/gitpod-io/gitpod/pull/17533",
      "https://github.com/gitpod-io/gitpod/pull/17495",
      "https://github.com/gitpod-io/gitpod/pull/17536",
      "https://github.com/gitpod-io/gitpod/pull/17535",
      "https://github.com/gitpod-io/gitpod/pull/17474",
      "https://github.com/gitpod-io/gitpod/pull/17524",
      "https://github.com/gitpod-io/gitpod/pull/17517",
      "https://github.com/gitpod-io/gitpod/pull/17520",
      "https://github.com/gitpod-io/gitpod/pull/17512",
      "https://github.com/gitpod-io/gitpod/pull/17480",
      "https://github.com/gitpod-io/gitpod/pull/17496",
      "https://github.com/gitpod-io/gitpod/pull/17222",
      "https://github.com/gitpod-io/gitpod/pull/17486",
      "https://github.com/gitpod-io/gitpod/pull/17481",
      "https://github.com/gitpod-io/gitpod/pull/17468",
      "https://github.com/gitpod-io/gitpod/pull/17449",
      "https://github.com/gitpod-io/gitpod/pull/17465",
      "https://github.com/gitpod-io/gitpod/pull/17453",
      "https://github.com/gitpod-io/gitpod/pull/17454",
      "https://github.com/gitpod-io/gitpod/pull/17462",
      "https://github.com/gitpod-io/gitpod/pull/17451",
      "https://github.com/gitpod-io/gitpod/pull/17443",
      "https://github.com/gitpod-io/gitpod/pull/17439",
      "https://github.com/gitpod-io/gitpod/pull/17393",
      "https://github.com/gitpod-io/gitpod/pull/17434",
      "https://github.com/gitpod-io/gitpod/pull/17429",
      "https://github.com/gitpod-io/gitpod/pull/17419",
      "https://github.com/gitpod-io/gitpod/pull/17136",
      "https://github.com/gitpod-io/gitpod/pull/17418",
      "https://github.com/gitpod-io/gitpod/pull/17412",
      "https://github.com/gitpod-io/gitpod/pull/17375",
      "https://github.com/gitpod-io/gitpod/pull/17368",
      "https://github.com/gitpod-io/gitpod/pull/17349",
      "https://github.com/gitpod-io/gitpod/pull/17366",
      "https://github.com/gitpod-io/gitpod/pull/17376",
      "https://github.com/gitpod-io/gitpod/pull/17362",
      "https://github.com/gitpod-io/gitpod/pull/17344",
      "https://github.com/gitpod-io/gitpod/pull/17317",
      "https://github.com/gitpod-io/gitpod/pull/17321",
      "https://github.com/gitpod-io/gitpod/pull/17316"
    ],
    "all": [
      "https://github.com/gitpod-io/gitpod/pull/17533",
      "https://github.com/gitpod-io/gitpod/pull/17495",
      "https://github.com/gitpod-io/gitpod/pull/17536",
      "https://github.com/gitpod-io/gitpod/pull/17535",
      "https://github.com/gitpod-io/gitpod/pull/17524",
      "https://github.com/gitpod-io/gitpod/pull/17517",
      "https://github.com/gitpod-io/gitpod/pull/17520",
      "https://github.com/gitpod-io/gitpod/pull/17512",
      "https://github.com/gitpod-io/gitpod/pull/17480",
      "https://github.com/gitpod-io/gitpod/pull/17496",
      "https://github.com/gitpod-io/gitpod/pull/17486",
      "https://github.com/gitpod-io/gitpod/pull/17481",
      "https://github.com/gitpod-io/gitpod/pull/17468",
      "https://github.com/gitpod-io/gitpod/pull/17449",
      "https://github.com/gitpod-io/gitpod/pull/17465",
      "https://github.com/gitpod-io/gitpod/pull/17453",
      "https://github.com/gitpod-io/gitpod/pull/17454",
      "https://github.com/gitpod-io/gitpod/pull/17462",
      "https://github.com/gitpod-io/gitpod/pull/17451",
      "https://github.com/gitpod-io/gitpod/pull/17439",
      "https://github.com/gitpod-io/gitpod/pull/17393",
      "https://github.com/gitpod-io/gitpod/pull/17434",
      "https://github.com/gitpod-io/gitpod/pull/17429",
      "https://github.com/gitpod-io/gitpod/pull/17419",
      "https://github.com/gitpod-io/gitpod/pull/17136",
      "https://github.com/gitpod-io/gitpod/pull/17418",
      "https://github.com/gitpod-io/gitpod/pull/17412",
      "https://github.com/gitpod-io/gitpod/pull/17375",
      "https://github.com/gitpod-io/gitpod/pull/17368",
      "https://github.com/gitpod-io/gitpod/pull/17366",
      "https://github.com/gitpod-io/gitpod/pull/17376",
      "https://github.com/gitpod-io/gitpod/pull/17362",
      "https://github.com/gitpod-io/gitpod/pull/17344",
      "https://github.com/gitpod-io/gitpod/pull/17317",
      "https://github.com/gitpod-io/gitpod/pull/17321",
      "https://github.com/gitpod-io/gitpod/pull/17316"
    ]
  },
  "errors": []
}
```